### PR TITLE
Further iteration on flexible device support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,7 +27,7 @@ freeze-deps:
 .PHONY: todo
 todo:
 	@less -f <(grep -r -I --exclude=Makefile --exclude-dir=.ruff_cache \
-	--exclude-dir=.venv --exclude-dir=examples 'TODO:' .) \
+	--exclude-dir=env --exclude-dir=examples 'TODO:' .) \
 	<(cat ./TODO.MD)
 
 .PHONY: dev_build_env

--- a/gui.py
+++ b/gui.py
@@ -192,7 +192,7 @@ class Dispaly(EventHandlingComponent):
 
         self.pressed_keys = set()
 
-        self.display_window = display_window = pygame_gui.elements.UIWindow(
+        self.display_window = pygame_gui.elements.UIWindow(
             element_id="display_window",
             window_display_title=title,
             rect=vm_display_rect,
@@ -203,7 +203,7 @@ class Dispaly(EventHandlingComponent):
         display_surface = pygame.Surface(self.display_surface_dims)
         self.display_image = pygame_gui.elements.UIImage(
             relative_rect=dim,
-            container=display_window,
+            container=self.display_window,
             image_surface=display_surface,
             manager=manager,
         )

--- a/virtual_machine.py
+++ b/virtual_machine.py
@@ -1,10 +1,48 @@
 from dataclasses import dataclass, field
+from functools import partial
 import logging
-from typing import Callable, MutableMapping, Optional, cast
+from typing import Callable, Mapping, MutableMapping, Optional, cast
 
 import vm_types
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class DefaultVideoDevice:
+    hardware_device_id = vm_types.HardwareDeviceIds.DISP0
+    color_format: vm_types.ColorFormats = vm_types.ColorFormats.RGB
+    resolution: vm_types.VideoResolution = vm_types.VideoResolution(320, 200)
+    buffer: Optional[memoryview] = None
+
+    def __post_init__(self):
+        self.buffer = memoryview(self.draw_pattern())
+
+    @property
+    def VRAM(self) -> memoryview:
+        if not self.buffer:
+            raise ValueError("Video device missing vram")
+        return self.buffer
+
+    def draw_pattern(self) -> bytearray:
+        # Place holder if no video device
+        w = self.resolution.width
+        h = self.resolution.heigth
+        color_depth = vm_types.ColorFormats.RGB.value.byte_size
+        bytes_data = bytearray(w * h * color_depth)
+        for y in range(0, h):
+            for x in range(0, w, 1):
+                row = (w * color_depth) * y
+                col = x * color_depth
+                bytes_data[row + col] = (x ^ y) % 255
+                bytes_data[row + col + 1] = 0
+                bytes_data[row + col + 2] = 0
+
+        return bytes_data
+
+    def update_on_state_change(self, data): ...
+
+    def device_tick(self): ...
 
 
 def device_register_port(
@@ -20,12 +58,26 @@ def device_register_port(
 
 @dataclass
 class DeviceManager:
-    video_device: Optional[vm_types.GenericVideoDevice] = None
+    video_devices: MutableMapping[
+        vm_types.HardwareDeviceIds, vm_types.GenericVideoDevice
+    ] = field(default_factory=dict)
+    char_devices: Mapping[
+        vm_types.HardwareDeviceIds, vm_types.GenericCharacterDevice
+    ] = field(default_factory=dict)
     _WRITE_TO_PORTS: MutableMapping[int, Callable] = field(default_factory=dict)
     _READ_FROM_PORTS: MutableMapping[int, Callable] = field(default_factory=dict)
 
     def __post_init__(self):
-        self._register_devices([self.video_device])
+        if vm_types.HardwareDeviceIds.DISP0 not in self.video_devices:
+            self.video_devices.update(
+                {vm_types.HardwareDeviceIds.DISP0: DefaultVideoDevice()}
+            )
+
+        self.all_devices = list(self.video_devices.values()) + list(
+            self.char_devices.values()
+        )
+
+        self._register_devices(self.all_devices)
 
     def _register_devices(self, devices):
         for device_object in devices:
@@ -41,13 +93,45 @@ class DeviceManager:
                         port_mapping = self._READ_FROM_PORTS
                     if port_handler.info.port_id in port_mapping:
                         raise ValueError(
-                            f"Port id={port_handler.info.port_id} " "already registerd"
+                            f"Port id={port_handler.info.port_id} " "already registered"
                         )
-                    port_mapping[port_handler.info.port_id] = port_handler
+                    port_mapping[port_handler.info.port_id] = partial(
+                        port_handler, device_object
+                    )
 
-    def read_port(self, port_id: int) -> int: ...
+    def process_devices_on_tick(self):
+        for device in self.all_devices:
+            device.device_tick()
 
-    def write_port(self, port_id: int, value: int): ...
+    def error_port_not_registered(self, port_id: int, read_port=True):
+        port_mapping = self._WRITE_TO_PORTS
+        if read_port:
+            port_mapping = self._READ_FROM_PORTS
+
+        if port_id not in port_mapping:
+            raise ValueError(f"Port id={port_id} {read_port=} not registered")
+
+    def read_port(self, port_id: int) -> int:
+        self.error_port_not_registered(port_id)
+        return self._READ_FROM_PORTS[port_id]()
+
+    def write_port(self, port_id: int, value: int):
+        self.error_port_not_registered(port_id, read_port=False)
+        self._WRITE_TO_PORTS[port_id](value)
+
+    def get_video_device(
+        self, hardware_device_id
+    ) -> Optional[vm_types.GenericVideoDevice]:
+        # TODO: (Hristo) this should be structured/ typed in a better way
+        video_device = self.video_devices.get(hardware_device_id)
+        return video_device
+
+    def get_char_device(
+        self, hardware_device_id
+    ) -> Optional[vm_types.GenericCharacterDevice]:
+        # TODO: (Hristo) this should be structured/ typed in a better way
+        char_device = self.char_devices.get(hardware_device_id)
+        return char_device
 
 
 @dataclass
@@ -78,39 +162,20 @@ class VirtualMachine:
     def get_current_instruction_address(self):
         return self.cpu.current_inst_address
 
-    @property
-    def video_memory(self) -> bytearray | memoryview:
-        # Place holder until video memory gets implemented
-        if self.device_manager.video_device:
-            bytes_data = self.device_manager.video_device.VRAM
-        else:
-            bytes_data = bytearray(320 * 200 * 3)
-            for y in range(0, 200):
-                for x in range(0, 320, 1):
-                    row = (320 * 3) * y
-                    col = x * 3
-                    bytes_data[row + col] = (x ^ y) % 255
-                    bytes_data[row + col + 1] = 0
-                    bytes_data[row + col + 2] = 0
-
-        return bytes_data
-
-    @property
-    def video_resolution(self):
-        if self.device_manager.video_device:
-            return self.device_manager.video_device.resolution
-        return vm_types.VideoResolution(320, 200)
-
     def load_at(self, address: int, data: bytearray, force=False):
-        # TODO: I think there is 1 off bug here looking how mem changes
         data_len = len(data)
         memory_len = len(self.memory)
 
         if not force and address % self.cpu.word_in_bytes != 0:
-            raise Exception("TODO")
+            raise ValueError(
+                f"Address {hex(address)} in not word boundary "
+                "use `force=True` to load anyway"
+            )
 
         if address < 0 or (address + data_len - 1) >= memory_len:
-            raise Exception("TODO")
+            raise ValueError(
+                f"Address {hex(address)} out side of range " f" 0 to {hex(memory_len)}"
+            )
 
         self.memory[address : len(data)] = data
 
@@ -140,6 +205,7 @@ class VirtualMachine:
         self.restart()
 
     def step(self, milli_sec_since_last: int):
+        self.device_manager.process_devices_on_tick()
         self._ellapsed_since_last += milli_sec_since_last
         if self._ellapsed_since_last < 1000 / self.clock_speed_hz:
             return


### PR DESCRIPTION
- Defined supported "hardware" devices that VM devices can subscribe to
- Update device protocols/ apis
  - Generic way to access device mem buffers
  - Update device change
    - Sets up possibility of raising interrupts
  - Process devices before cpu tick
- Fix calling of port IO callables, methods bound to device instance
- Toy VM test program can now read kbd and exit if RETURN was pressed during check